### PR TITLE
Include algorithm header

### DIFF
--- a/expansion_lt/src/voronotalt/basic_types_and_functions.h
+++ b/expansion_lt/src/voronotalt/basic_types_and_functions.h
@@ -1,6 +1,7 @@
 #ifndef VORONOTALT_BASIC_TYPES_AND_FUNCTIONS_H_
 #define VORONOTALT_BASIC_TYPES_AND_FUNCTIONS_H_
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 


### PR DESCRIPTION
Used `std::max` is in the `algorithm` header. https://en.cppreference.com/w/cpp/algorithm/max.html