### PR TITLE
Bump cmake_minimum_required to 3.6 as with CMake 4 levels < 3.5 are gone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 
 project(Voronota)
 

--- a/expansion_gl/CMakeLists.txt
+++ b/expansion_gl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 
 project(Voronota-GL)
 

--- a/expansion_js/CMakeLists.txt
+++ b/expansion_js/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 
 project(Voronota-JS)
 

--- a/expansion_lt/CMakeLists.txt
+++ b/expansion_lt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 
 project(Voronota-LT)
 


### PR DESCRIPTION
With CMake 4, compatibility levels < 3.5 are no longer supported. This has been reported as an issue on Debian ([#1113623](https://bugs.debian.org/1113623)). I have checked, with `cmake_minimum_required()` bumped to 3.6, build works as before.